### PR TITLE
Fix inline object/callback creation causing unnecessary rerenders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Sphere is a geospatial data visualization and editing desktop application built with Tauri (Rust backend) and React/TypeScript (frontend) using MapLibre GL for map rendering. It supports loading GeoJSON, Shapefile, CSV, GPX, and MBTiles formats.
 
+## Git Conventions
+
+- Branch names use the format `issue-XX` (e.g. `issue-79`)
+
 ## Build & Development Commands
 
 ```bash

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react"
 import { MapProvider } from "react-map-gl/maplibre"
 import { ErrorBoundary } from "react-error-boundary"
 import { Center } from "@mantine/core"
@@ -17,9 +18,21 @@ import PropertiesPopup from "../PropertiesPopup"
 import { ErrorFallback } from "@/ui/ErrorFallback"
 import logger from "@/logger"
 
+const WORKING_INDICATOR_STYLE: React.CSSProperties = {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    width: 28,
+    height: 28,
+}
+
 export default function App() {
     const id = MAP_ID
     const dispatch = useAppDispatch()
+
+    const onResize = useCallback(() => {
+        dispatch(actions.map.resize(id))
+    }, [dispatch, id])
     const zen = useAppSelector(selectors.app.isZen)
     const left = useAppSelector(selectShowLeftSidebar)
 
@@ -39,17 +52,9 @@ export default function App() {
                             startWidth={300}
                             minWidth={265}
                             maxWidth={500}
-                            onResize={() => {
-                                dispatch(actions.map.resize(id))
-                            }}
+                            onResize={onResize}
                         >
-                            <Center style={{
-                                position: "absolute",
-                                top: 0,
-                                right: 0,
-                                width: 28,
-                                height: 28,
-                            }}>
+                            <Center style={WORKING_INDICATOR_STYLE}>
                                 <WorkingIndicator />
                             </Center>
                             <ErrorBoundary

--- a/src/components/LeftSidebar/index.tsx
+++ b/src/components/LeftSidebar/index.tsx
@@ -3,6 +3,11 @@ import { IconDatabase, IconSquaresFilled, IconStack } from "@tabler/icons"
 import { LayersTab } from "./LayersTab"
 import { SourcesTab } from "./SourcesTab"
 
+const PANEL_STYLE: React.CSSProperties = {
+    width: 300,
+    overflow: "hidden",
+}
+
 export function StyledTabs(props: TabsProps) {
     return (
         <Tabs unstyled styles={(theme) => ({
@@ -91,19 +96,13 @@ export const LeftSidebar: React.FC = () => {
             </Tabs.Panel>
 
             <Tabs.Panel value="map-styles">
-                <Paper p={"sm"} style={{
-                    width: 300,
-                    overflow: "hidden",
-                }}>
+                <Paper p={"sm"} style={PANEL_STYLE}>
                     Map Styles
                 </Paper>
             </Tabs.Panel>
 
             <Tabs.Panel value="settings">
-                <Paper p={"sm"} style={{
-                    width: 300,
-                    overflow: "hidden",
-                }}>
+                <Paper p={"sm"} style={PANEL_STYLE}>
                     Settings
                 </Paper>
             </Tabs.Panel>

--- a/src/components/MapStatusbar/index.tsx
+++ b/src/components/MapStatusbar/index.tsx
@@ -1,5 +1,6 @@
+import { useCallback, useMemo } from "react"
 import { useMap } from "react-map-gl/maplibre"
-import { ActionIcon, Badge, MantineProvider, createStyles } from "@mantine/core"
+import { ActionIcon, Badge, MantineProvider, MantineTheme, createStyles } from "@mantine/core"
 import { Statusbar } from "@/ui/Statusbar"
 import { useCursor } from "@/hooks/useCursor"
 import { useZoom } from "@/hooks/useZoom"
@@ -99,32 +100,60 @@ export const MapStatusbar: React.FC<MapStatusbarProps> = ({ id }) => {
     const errorMessage = useAppSelector(selectErrorMessage)
     const isGlobe = projection === "globe"
 
+    const toggleSidebar = useCallback(() => {
+        if (sidebar) {
+            dispatch(actions.app.hideLeftSidebar())
+        } else {
+            dispatch(actions.app.showLeftSidebar())
+        }
+    }, [dispatch, sidebar])
+
+    const printViewport = useCallback(() => {
+        dispatch(actions.map.printViewport({ mapId: MAP_ID }))
+    }, [dispatch])
+
+    const resetNorth = useCallback(() => {
+        dispatch(actions.map.resetNorth({ mapId: MAP_ID }))
+    }, [dispatch])
+
+    const setSatellite = useCallback(() => {
+        dispatch(actions.mapStyle.setSatellite())
+    }, [dispatch])
+
+    const toggleTerrain = useCallback(() => {
+        dispatch(actions.terrain.toggle())
+    }, [dispatch])
+
+    const toggleProjection = useCallback(() => {
+        if (isGlobe) {
+            dispatch(actions.projection.setFlat())
+        } else {
+            dispatch(actions.projection.setGlobe())
+        }
+    }, [dispatch, isGlobe])
+
+    const mantineTheme = useMemo(() => ({
+        components: {
+            ActionIcon: {
+                defaultProps: (theme: MantineTheme) => ({
+                    ...actionIconDefaultProps,
+                    className: s.icon,
+                    sx: {
+                        "&[data-disabled]": {
+                            backgroundColor: "#00000000",
+                            color: theme.colors.gray[8],
+                            border: "none",
+                        },
+                    },
+                }),
+            },
+        },
+    }), [s.icon])
+
     return (
         <Statusbar>
-            <MantineProvider theme={{
-                components: {
-                    ActionIcon: {
-                        defaultProps: theme => ({
-                            ...actionIconDefaultProps,
-                            className: s.icon,
-                            sx: {
-                                "&[data-disabled]": {
-                                    backgroundColor: "#00000000",
-                                    color: theme.colors.gray[8],
-                                    border: "none",
-                                },
-                            },
-                        }),
-                    },
-                },
-            }}>
-                <ActionIcon className={cx(s.icon, { [s.active]: sidebar })} onClick={() => {
-                    if (sidebar) {
-                        dispatch(actions.app.hideLeftSidebar())
-                    } else {
-                        dispatch(actions.app.showLeftSidebar())
-                    }
-                }}>
+            <MantineProvider theme={mantineTheme}>
+                <ActionIcon className={cx(s.icon, { [s.active]: sidebar })} onClick={toggleSidebar}>
                     <IconLayoutSidebar size={16} />
                 </ActionIcon>
 
@@ -144,25 +173,17 @@ export const MapStatusbar: React.FC<MapStatusbarProps> = ({ id }) => {
 
                 <div className={s.s} />
 
-                <ActionIcon onClick={() => {
-                    dispatch(actions.map.printViewport({ mapId: MAP_ID }))
-                }}>
+                <ActionIcon onClick={printViewport}>
                     <IconLiveView size={16} />
                 </ActionIcon>
 
-                <ActionIcon onClick={() => {
-                    dispatch(actions.map.resetNorth({ mapId: MAP_ID }))
-                }}>
+                <ActionIcon onClick={resetNorth}>
                     <IconNorthStar size={16} />
                 </ActionIcon>
-                <ActionIcon disabled onClick={() => {
-                    dispatch(actions.mapStyle.setSatellite())
-                }}>
+                <ActionIcon disabled onClick={setSatellite}>
                     <IconSatellite size={16} />
                 </ActionIcon>
-                <ActionIcon disabled onClick={() => {
-                    dispatch(actions.terrain.toggle())
-                }}>
+                <ActionIcon disabled onClick={toggleTerrain}>
                     {terrain ? (
                         <IconMountain size={16} />
                     ) : (
@@ -172,13 +193,7 @@ export const MapStatusbar: React.FC<MapStatusbarProps> = ({ id }) => {
                 <ActionIcon
                     color={isGlobe ? "yellow" : undefined}
                     disabled={!changeProjection}
-                    onClick={() => {
-                        if (isGlobe) {
-                            dispatch(actions.projection.setFlat())
-                        } else {
-                            dispatch(actions.projection.setGlobe())
-                        }
-                    }}
+                    onClick={toggleProjection}
                 >
                     {isGlobe ? (
                         <IconWorld size={16} />

--- a/src/components/PhotoLayer/index.tsx
+++ b/src/components/PhotoLayer/index.tsx
@@ -10,6 +10,10 @@ import { InvisibleCircleLayer } from "./InvisibleCircleLayer"
 import type { GetImageFunction } from "./types"
 import { useFeatures } from "./hooks"
 
+const PHOTO_CONTAINER_STYLE: React.CSSProperties = { position: "relative", zIndex: 0 }
+const MARKER_STYLE_ACTIVE: React.CSSProperties = { zIndex: 100 }
+const MARKER_STYLE_INACTIVE: React.CSSProperties = { zIndex: 1 }
+
 export type PhotoLayerProps = {
     layerId: string
     sourceId: string
@@ -88,7 +92,7 @@ export const PhotoLayer: React.FC<PhotoLayerProps> = ({ sourceId, layerId, sourc
         const active = activeImage === id
 
         return (
-            <div key={id} style={{ position: "relative", zIndex: 0 }}>
+            <div key={id} style={PHOTO_CONTAINER_STYLE}>
                 <Marker
                     longitude={lng}
                     latitude={lat}
@@ -97,11 +101,7 @@ export const PhotoLayer: React.FC<PhotoLayerProps> = ({ sourceId, layerId, sourc
 
                         setActiveImage(id)
                     }}
-                    style={{
-                        zIndex: active
-                            ? 100
-                            : 1,
-                    }}
+                    style={active ? MARKER_STYLE_ACTIVE : MARKER_STYLE_INACTIVE}
                 >
                     <ImageMarker
                         src={src}

--- a/src/components/PropertiesPopup/index.tsx
+++ b/src/components/PropertiesPopup/index.tsx
@@ -4,6 +4,11 @@ import { selectProperties } from "@/store/properties"
 import { PropertiesViewer } from "@/ui/PropertiesViewer"
 import { Overlay } from "@/ui/Overlay"
 
+const CONTAINER_STYLE: React.CSSProperties = {
+    minWidth: 300,
+    overflow: "hidden",
+}
+
 export default function PropertiesPopup() {
     const props = useAppSelector(selectProperties)
     if (!props) {
@@ -12,10 +17,7 @@ export default function PropertiesPopup() {
 
     return (
         <Overlay topRight={(
-            <Container pt={"lg"} style={{
-                minWidth: 300,
-                overflow: "hidden",
-            }}>
+            <Container pt={"lg"} style={CONTAINER_STYLE}>
                 <Paper p={"sm"}>
                     <Title order={3}>
                         Properties


### PR DESCRIPTION
## Summary
- Extract static style objects to module-level constants in `App`, `PhotoLayer`, `PropertiesPopup`, and `LeftSidebar`
- Wrap event handlers in `useCallback` and memoize theme object with `useMemo` in `MapStatusbar`
- Document branch naming convention in CLAUDE.md

## Test Plan
- [x] `npm run lint` — 0 errors, no new warnings
- [x] `npm test` — 201/201 passing