### PR TITLE
Replace any types and unsafe assertions (#91)

### DIFF
--- a/src/components/PhotoLayer/index.tsx
+++ b/src/components/PhotoLayer/index.tsx
@@ -5,7 +5,6 @@ import { Badge } from "./Badge"
 import { PhotoCluster, RenderPhotoFunction } from "./PhotoCluster"
 import { useDispatch } from "react-redux"
 import { actions } from "@/store"
-import * as maplibregl from "maplibre-gl"
 import { InvisibleCircleLayer } from "./InvisibleCircleLayer"
 import type { GetImageFunction } from "./types"
 import { useFeatures } from "./hooks"
@@ -33,7 +32,7 @@ export const PhotoLayer: React.FC<PhotoLayerProps> = ({ sourceId, layerId, sourc
     const features = useFeatures({
         sourceId,
         layerId: invisiblePointsLayer,
-        map: current?.getMap() as unknown as maplibregl.Map,
+        map: current?.getMap(),
     })
 
     useEffect(() => {
@@ -58,9 +57,9 @@ export const PhotoLayer: React.FC<PhotoLayerProps> = ({ sourceId, layerId, sourc
         let id = feature.id! // useFeatures hook makes sure feature has id
 
         if (isCluster) {
-            const src = feature.properties!.src
-            id = feature.properties!.cluster_id
-            const clusterSize = feature.properties!.point_count
+            const src = feature.properties?.src
+            id = feature.properties?.cluster_id
+            const clusterSize = feature.properties?.point_count
 
             return (
                 <Marker key={id} longitude={lng} latitude={lat}>
@@ -70,7 +69,7 @@ export const PhotoLayer: React.FC<PhotoLayerProps> = ({ sourceId, layerId, sourc
                         layout={iconLayout}
                         onHover={() => {
                             dispatch(actions.properties.set({
-                                values: feature.properties!,
+                                values: feature.properties ?? {},
                             }))
                         }}
                         onLeaveHover={() => {
@@ -88,7 +87,7 @@ export const PhotoLayer: React.FC<PhotoLayerProps> = ({ sourceId, layerId, sourc
             )
         }
 
-        const { src } = getImage(feature.properties!)
+        const { src } = getImage(feature.properties)
         const active = activeImage === id
 
         return (
@@ -109,7 +108,7 @@ export const PhotoLayer: React.FC<PhotoLayerProps> = ({ sourceId, layerId, sourc
                         layout={iconLayout}
                         onHover={() => {
                             dispatch(actions.properties.set({
-                                values: feature.properties!,
+                                values: feature.properties ?? {},
                             }))
                         }}
                         onLeaveHover={() => {
@@ -131,9 +130,9 @@ export const PhotoLayer: React.FC<PhotoLayerProps> = ({ sourceId, layerId, sourc
             <PhotoCluster
                 radius={clusterRadius}
                 data={features.filter(f => {
-                    const { src } = getImage(f.properties!)
+                    const { src } = getImage(f.properties)
                     return !!src
-                }) as any}
+                }) as GeoJSON.Feature<GeoJSON.Point, { [key: string]: string | number }>[]}
                 renderPhoto={renderPhoto}
                 mapProperties={getImage}
             />

--- a/src/components/SphereMap/SphereLayer.tsx
+++ b/src/components/SphereMap/SphereLayer.tsx
@@ -15,11 +15,11 @@ import { sourceLayerProp, visibility } from "@/lib/maplibre"
 
 function createGetImageFunction({ srcField, valueField }: { srcField: string, valueField: string }): GetImageFunction {
     return properties => {
-        const src = properties![srcField] as string
+        const src = properties?.[srcField] as string
 
         return {
             src,
-            value: properties![valueField] ?? 0,
+            value: properties?.[valueField] ?? 0,
         }
     }
 }

--- a/src/hooks/useClusters.ts
+++ b/src/hooks/useClusters.ts
@@ -5,9 +5,7 @@ import Supercluster from "supercluster"
 import { useMapboxEvent } from "./useMapboxEvent"
 import logger from "@/logger"
 
-type DefaultFeatureProperties = {
-    [key: string]: any
-}
+type DefaultFeatureProperties = Supercluster.AnyProps
 export type ClustersOptions<P extends Supercluster.AnyProps, C> = Supercluster.Options<P, C>
 export function useClusters<
     P extends Supercluster.AnyProps = DefaultFeatureProperties,

--- a/src/hooks/useSky.ts
+++ b/src/hooks/useSky.ts
@@ -2,37 +2,35 @@ import type { SkySpecification } from "maplibre-gl"
 import type { MapRef } from "react-map-gl/maplibre"
 import { useEffect } from "react"
 
+type MapWithSky = ReturnType<MapRef["getMap"]> & { setSky(sky?: SkySpecification): void }
+
 export type SkyProps = {
     mapId: string
 }
 
 export default function useSky(ref: MapRef | undefined, sky: SkySpecification | undefined) {
     useEffect(() => {
-        const map = ref?.getMap()
+        const map = ref?.getMap() as MapWithSky | undefined
         if (!map) {
             return
         }
 
         if (map.isStyleLoaded()) {
-            // @ts-expect-error this is official api for reseting sky settings
             map.setSky(sky)
             return () => {
                 if (map.isStyleLoaded()) {
-                    // @ts-expect-error this is official api for reseting sky settings
                     map.setSky(undefined)
                 }
             }
         }
 
         const load = map.on("load", () => {
-            // @ts-expect-error this is official api for reseting sky settings
             map.setSky(sky)
         })
 
         return () => {
             load.unsubscribe()
             if (map.isStyleLoaded()) {
-                // @ts-expect-error this is official api for reseting sky settings
                 map.setSky(undefined)
             }
         }

--- a/src/store/layer/index.ts
+++ b/src/store/layer/index.ts
@@ -144,56 +144,62 @@ export const layerSlice = createSlice({
         setCircleRadius: (state, action: PayloadAction<{ id: Id, min: number, max: number }>) => {
             const { id, min, max } = action.payload
             const layer = state.items[id]
-            layer.circle!.minRadius = min
-            layer.circle!.maxRadius = max
+            if (!layer.circle) return
+            layer.circle.minRadius = min
+            layer.circle.maxRadius = max
         },
         setHeatmapParameters: (state, action: PayloadAction<{ id: Id, radius?: number, intensity?: number }>) => {
             const { id, radius, intensity } = action.payload
             const layer = state.items[id]
+            if (!layer.heatmap) return
             if (typeof radius !== "undefined") {
-                layer.heatmap!.radius = radius
+                layer.heatmap.radius = radius
             }
             if (typeof intensity !== "undefined") {
-                layer.heatmap!.intensity = intensity
+                layer.heatmap.intensity = intensity
             }
         },
         setPhotoIconLayout: (state, action: PayloadAction<{ id: Id, value: PhotoIconLayout }>) => {
             const { id, value } = action.payload
             const layer = state.items[id]
-            layer.photo!.icon = value
+            if (!layer.photo) return
+            layer.photo.icon = value
         },
         setPhotoClusterRadius: (state, action: PayloadAction<{ id: Id, value: number }>) => {
             const { id, value } = action.payload
             const layer = state.items[id]
-            layer.photo!.clusterRadius = value
+            if (!layer.photo) return
+            layer.photo.clusterRadius = value
         },
         setPhotoField: (state, action: PayloadAction<{ id: Id, src?: string, value?: string, count?: string }>) => {
             const { id, src, value, count } = action.payload
             const layer = state.items[id]
+            if (!layer.photo) return
             if (src) {
-                layer.photo!.srcField = src
+                layer.photo.srcField = src
             }
             if (value) {
-                layer.photo!.valueField = value
+                layer.photo.valueField = value
             }
             if (count) {
-                layer.photo!.countField = count
+                layer.photo.countField = count
             }
         },
         setExtrusionOptions: (state, action: PayloadAction<{ id: Id, base?: number, height?: number, baseField?: string, heightField?: string }>) => {
             const { id, base, height, baseField, heightField } = action.payload
             const layer = state.items[id]
+            if (!layer.extrusion) return
             if (typeof base !== "undefined") {
-                layer.extrusion!.base = base
+                layer.extrusion.base = base
             }
             if (typeof height !== "undefined") {
-                layer.extrusion!.height = height
+                layer.extrusion.height = height
             }
             if (typeof baseField !== "undefined") {
-                layer.extrusion!.baseField = baseField
+                layer.extrusion.baseField = baseField
             }
             if (typeof heightField !== "undefined") {
-                layer.extrusion!.heightField = heightField
+                layer.extrusion.heightField = heightField
             }
         },
     },

--- a/src/store/mapStyle.ts
+++ b/src/store/mapStyle.ts
@@ -1,5 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit"
 import type { PayloadAction } from "@reduxjs/toolkit"
+import { castDraft } from "immer"
 import type { StyleSpecification } from "maplibre-gl"
 import { STYLE_OSM, STYLE_VECTOR, STYLE_SATELLITE } from "@/const"
 
@@ -27,11 +28,11 @@ export const mapStyleSlice = createSlice({
             state.value = STYLE_SATELLITE
         },
         setOsm: state => {
-            state.value = STYLE_OSM as any
+            state.value = castDraft(STYLE_OSM)
         },
         // Use the PayloadAction type to declare the contents of `action.payload`
         setMapStyle: (state, action: PayloadAction<MapStyle>) => {
-            state.value = action.payload as any
+            state.value = castDraft(action.payload)
         },
     },
 })

--- a/src/ui/Outline/Card.tsx
+++ b/src/ui/Outline/Card.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react"
 import { useDrag, useDrop } from "react-dnd"
+import type { DragSourceMonitor } from "react-dnd"
 import { ItemTypes } from "./type"
 import type { Identifier, XYCoord } from "dnd-core"
 
@@ -79,7 +80,7 @@ export const Card: React.FC<CardProps> = ({ id, children, index, onMove }) => {
         item: () => {
             return { id, index }
         },
-        collect: (monitor: any) => ({
+        collect: (monitor: DragSourceMonitor) => ({
             isDragging: monitor.isDragging(),
         }),
     })


### PR DESCRIPTION
closes #91 

Replace `any` types and unsafe non-null assertions with proper types across the codebase.

- `mapStyle.ts`: use `castDraft()` from immer instead of `as any` for Immer draft assignments
- `useSky.ts`: add `MapWithSky` helper type, remove 4 `@ts-expect-error` suppressions
- `Card.tsx`: import and use `DragSourceMonitor` instead of `monitor: any`
- `useClusters.ts`: replace local `DefaultFeatureProperties` with `Supercluster.AnyProps`
- `PhotoLayer/index.tsx`: remove double cast, replace `properties!` with optional chaining/nullish coalescing, type filter result explicitly
- `SphereLayer.tsx`: replace `properties![field]` with `properties?.[field]`
- `store/layer/index.ts`: add `if (!layer.X) return` guards in `setCircleRadius`, `setHeatmapParameters`, `setPhotoIconLayout`, `setPhotoClusterRadius`, `setPhotoField`, `setExtrusionOptions`