### PR TITLE
Update CI actions to latest versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,10 +15,10 @@ jobs:
         runs-on: ${{ matrix.platform }}
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24
 

--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -13,9 +13,9 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: npm
@@ -25,9 +25,9 @@ jobs:
     typecheck:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: npm
@@ -37,9 +37,9 @@ jobs:
     format:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: npm
@@ -50,9 +50,9 @@ jobs:
         needs: [format, typecheck, lint]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: npm
@@ -63,9 +63,9 @@ jobs:
         needs: [test]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: npm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
     test-libexpression:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
                   toolchain: 1.92
@@ -20,7 +20,7 @@ jobs:
     test-libsphere:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
                   toolchain: 1.92
@@ -31,7 +31,7 @@ jobs:
     test-mbtiles:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
                   toolchain: 1.92
@@ -42,7 +42,7 @@ jobs:
     test-tilejson:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
                   toolchain: 1.92
@@ -53,7 +53,7 @@ jobs:
     test-tauri:
         runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
                   toolchain: 1.92


### PR DESCRIPTION
Upgrades `actions/checkout` and `actions/setup-node` from v4 to v6 across all workflow files. `actions-rust-lang/setup-rust-toolchain` remains at v1 (already latest major).

Closes #137