### PR TITLE
Do not show context menu on map rotation

### DIFF
--- a/src/components/MapContextMenu/index.test.tsx
+++ b/src/components/MapContextMenu/index.test.tsx
@@ -1,6 +1,12 @@
-import { fireEvent, render, screen } from "@/test-utils"
+import { render, screen } from "@/test-utils"
+import { act } from "react"
 import { describe, expect, it, vi } from "vitest"
 import { MapContextMenu } from "."
+import type { MapLayerMouseEvent } from "react-map-gl/maplibre"
+
+type MapEventHandler = (e: MapLayerMouseEvent) => void
+
+let contextmenuHandler: MapEventHandler | null = null
 
 vi.mock("react-map-gl/maplibre", async importOriginal => {
     const actual = await importOriginal<typeof import("react-map-gl/maplibre")>()
@@ -9,8 +15,19 @@ vi.mock("react-map-gl/maplibre", async importOriginal => {
         useMap: () => ({
             map: {
                 getMap: () => ({
-                    on: vi.fn(),
-                    off: vi.fn(),
+                    on: (event: string, handler: MapEventHandler) => {
+                        if (event === "contextmenu") {
+                            contextmenuHandler = handler
+                        }
+                    },
+                    off: (event: string) => {
+                        if (event === "contextmenu") {
+                            contextmenuHandler = null
+                        }
+                    },
+                    getContainer: () => ({
+                        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+                    }),
                 }),
             },
         }),
@@ -21,14 +38,28 @@ vi.mock("@/hooks/useCursor", () => ({
     useCursor: () => [10, 20] as [number, number],
 }))
 
+function fireMapContextMenu(point: { x: number; y: number }) {
+    contextmenuHandler?.({
+        point,
+        preventDefault: vi.fn(),
+    } as unknown as MapLayerMouseEvent)
+}
+
 describe("MapContextMenu", () => {
-    it("renders the Copy location menu item after contextmenu event", () => {
+    it("does not show menu initially", () => {
         render(<MapContextMenu id="map" copyLocationValue={([lng, lat]) => `${lng},${lat}`} />)
-        fireEvent.contextMenu(document)
+        expect(screen.queryByText("Copy location")).toBeNull()
+    })
+
+    it("shows menu after MapLibre contextmenu event", () => {
+        render(<MapContextMenu id="map" copyLocationValue={([lng, lat]) => `${lng},${lat}`} />)
+        act(() => {
+            fireMapContextMenu({ x: 100, y: 200 })
+        })
         expect(screen.getByText("Copy location")).toBeDefined()
     })
 
-    it("calls copyLocationValue with the mocked coord when Copy location is clicked", () => {
+    it("calls copyLocationValue with the cursor coord", () => {
         const copyLocationValue = vi.fn(([lng, lat]: [number, number]) => `${lng},${lat}`)
         render(<MapContextMenu id="map" copyLocationValue={copyLocationValue} />)
         expect(copyLocationValue).toHaveBeenCalledWith([10, 20])

--- a/src/components/MapContextMenu/index.tsx
+++ b/src/components/MapContextMenu/index.tsx
@@ -2,7 +2,9 @@ import { useCursor } from "@/hooks/useCursor"
 import { ContextMenu } from "@/ui/ContextMenu"
 import { CopyButton, Menu, Text } from "@mantine/core"
 import { IconCopy, IconSearch } from "@tabler/icons"
+import { useCallback, useEffect, useState } from "react"
 import { useMap } from "react-map-gl/maplibre"
+import type { MapLayerMouseEvent } from "react-map-gl/maplibre"
 
 export type LocationToString = (coord: [number, number]) => string
 
@@ -14,9 +16,32 @@ export type MapContextMenuProps = {
 export const MapContextMenu: React.FC<MapContextMenuProps> = ({ id, copyLocationValue }) => {
     const { [id]: ref } = useMap()
     const coord = useCursor(ref)
+    const [opened, setOpened] = useState(false)
+    const [position, setPosition] = useState<[number, number]>([0, 0])
+
+    useEffect(() => {
+        const map = ref?.getMap()
+        if (!map) return
+
+        const handler = (e: MapLayerMouseEvent) => {
+            e.preventDefault()
+            const rect = map.getContainer().getBoundingClientRect()
+            setPosition([e.point.x + rect.left, e.point.y + rect.top])
+            setOpened(true)
+        }
+
+        map.on("contextmenu", handler)
+        return () => {
+            map.off("contextmenu", handler)
+        }
+    }, [ref])
+
+    const handleClose = useCallback(() => {
+        setOpened(false)
+    }, [])
 
     return (
-        <ContextMenu>
+        <ContextMenu opened={opened} position={position} onClose={handleClose}>
             <Menu.Label>Map</Menu.Label>
             <CopyButton value={copyLocationValue(coord)}>
                 {({ copy }) => (
@@ -25,9 +50,6 @@ export const MapContextMenu: React.FC<MapContextMenuProps> = ({ id, copyLocation
                     </Menu.Item>
                 )}
             </CopyButton>
-            {/* <Menu.Item icon={<IconSettings size={14} />}>Settings</Menu.Item> */}
-            {/* <Menu.Item icon={<IconMessageCircle size={14} />}>Messages</Menu.Item> */}
-            {/* <Menu.Item icon={<IconPhoto size={14} />}>Gallery</Menu.Item> */}
             <Menu.Item
                 disabled
                 icon={<IconSearch size={14} />}
@@ -39,11 +61,6 @@ export const MapContextMenu: React.FC<MapContextMenuProps> = ({ id, copyLocation
             >
                 Search
             </Menu.Item>
-
-            {/* <Menu.Divider /> */}
-            {/* <Menu.Label>Danger zone</Menu.Label> */}
-            {/* <Menu.Item icon={<IconArrowsLeftRight size={14} />}>Transfer my data</Menu.Item> */}
-            {/* <Menu.Item color="red" icon={<IconTrash size={14} />}>Delete my account</Menu.Item> */}
         </ContextMenu>
     )
 }

--- a/src/ui/ContextMenu/index.test.tsx
+++ b/src/ui/ContextMenu/index.test.tsx
@@ -1,42 +1,32 @@
-import { fireEvent, render, screen } from "@/test-utils"
-import { act } from "react"
-import { describe, expect, it } from "vitest"
+import { render, screen } from "@/test-utils"
+import { describe, expect, it, vi } from "vitest"
 import { ContextMenu } from "."
 
 describe("ContextMenu", () => {
-    it("renders its children after a contextmenu event opens the menu", () => {
+    it("renders children when opened is true", () => {
         render(
-            <ContextMenu>
-                <div data-testid="child">hello</div>
-            </ContextMenu>,
-        )
-        fireEvent.contextMenu(document)
-        expect(screen.getByTestId("child")).toBeDefined()
-    })
-
-    it("shows the menu after a contextmenu event on document", () => {
-        render(
-            <ContextMenu>
+            <ContextMenu opened={true} position={[100, 200]} onClose={vi.fn()}>
                 <div data-testid="menu-item">Item</div>
             </ContextMenu>,
         )
-        fireEvent.contextMenu(document)
         expect(screen.getByTestId("menu-item")).toBeDefined()
     })
 
-    it("positions the Menu.Target div at the event's clientX/clientY", async () => {
+    it("does not render children when opened is false", () => {
+        render(
+            <ContextMenu opened={false} position={[100, 200]} onClose={vi.fn()}>
+                <div data-testid="menu-item">Item</div>
+            </ContextMenu>,
+        )
+        expect(screen.queryByTestId("menu-item")).toBeNull()
+    })
+
+    it("positions the target div at the given position", () => {
         const { container } = render(
-            <ContextMenu>
+            <ContextMenu opened={true} position={[100, 200]} onClose={vi.fn()}>
                 <div>Item</div>
             </ContextMenu>,
         )
-
-        await act(async () => {
-            document.dispatchEvent(
-                new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 100, clientY: 200 }),
-            )
-        })
-
         const target = container.querySelector("div[style]") as HTMLElement
         expect(target.style.left).toBe("100px")
         expect(target.style.top).toBe("200px")

--- a/src/ui/ContextMenu/index.tsx
+++ b/src/ui/ContextMenu/index.tsx
@@ -1,55 +1,29 @@
 import { Menu } from "@mantine/core"
-import { useToggle } from "@mantine/hooks"
-import { useEffect, useState } from "react"
 
 export type ContextMenuProps = {
+    opened: boolean
+    position: [number, number]
+    onClose: () => void
     children: React.ReactNode
 }
 
-export const ContextMenu: React.FC<ContextMenuProps> = ({ children }) => {
-    const [showContext, toggleShowContext] = useToggle<boolean>()
-    const [contextCoord, setContextCoord] = useState<[number, number]>([0, 0])
-
-    useEffect(() => {
-        const callback = (event: MouseEvent) => {
-            const xPos = event.clientX
-            const yPos = event.clientY
-
-            toggleShowContext(true)
-            setContextCoord([xPos, yPos])
-            event.preventDefault()
-            return false
-        }
-
-        document.addEventListener("contextmenu", callback, {
-            capture: true,
-        })
-
-        return () => {
-            document.removeEventListener("contextmenu", callback, {
-                capture: true,
-            })
-        }
-    }, [toggleShowContext])
-
+export const ContextMenu: React.FC<ContextMenuProps> = ({ opened, position, onClose, children }) => {
     return (
         <Menu
             shadow="md"
             width={200}
-            opened={showContext}
+            opened={opened}
             position={"right-start"}
             offset={10}
             closeOnClickOutside={true}
-            onClose={() => {
-                toggleShowContext(false)
-            }}
+            onClose={onClose}
         >
             <Menu.Target>
                 <div
                     style={{
                         position: "fixed",
-                        left: contextCoord[0],
-                        top: contextCoord[1],
+                        left: position[0],
+                        top: position[1],
                     }}
                 />
             </Menu.Target>


### PR DESCRIPTION
## Summary
- Use MapLibre's `contextmenu` map event instead of the DOM `contextmenu` event, which already handles the macOS quirk where `contextmenu` fires on mousedown (before any drag)
- Convert `ContextMenu` UI component to a controlled component (`opened`, `position`, `onClose` props)
- `MapContextMenu` listens to `map.on("contextmenu")` and offsets position by the map container's bounding rect

Closes #182