### PR TITLE
Upgrade to Biome 2.4.11 (#211)

### DIFF
--- a/apps/sphere/src/components/App/index.tsx
+++ b/apps/sphere/src/components/App/index.tsx
@@ -32,7 +32,7 @@ export default function App() {
 
     const onResize = useCallback(() => {
         dispatch(actions.map.resize(id))
-    }, [dispatch, id])
+    }, [dispatch])
 
     const copy = useCallback<LocationToString>(([lng, lat]) => `lng=${lng} lat=${lat}`, [])
 

--- a/apps/sphere/src/components/LayersOutline/index.tsx
+++ b/apps/sphere/src/components/LayersOutline/index.tsx
@@ -14,7 +14,7 @@ const selectLayers = createSelector(
             .map(id => {
                 const item = items[id]
 
-                let bulbIconColor: string | undefined = undefined
+                let bulbIconColor: string | undefined
                 if (dark && !!item.sourceId) {
                     bulbIconColor = "yellow"
                 }

--- a/apps/sphere/src/components/MapContextMenu/index.tsx
+++ b/apps/sphere/src/components/MapContextMenu/index.tsx
@@ -18,6 +18,7 @@ export type MapContextMenuProps = {
 
 export const MapContextMenu: React.FC<MapContextMenuProps> = ({ id, copyLocationValue }) => {
     const { [id]: ref } = useMap()
+    const map = ref?.getMap() ?? null
     const coord = useCursor(ref)
     const [opened, setOpened] = useState(false)
     const [position, setPosition] = useState<[number, number]>([0, 0])
@@ -30,7 +31,6 @@ export const MapContextMenu: React.FC<MapContextMenuProps> = ({ id, copyLocation
     const hasSelection = selectionCount > 0 && selectionSourceId !== undefined
 
     useEffect(() => {
-        const map = ref?.getMap()
         if (!map) return
 
         const handler = (e: MapLayerMouseEvent) => {
@@ -44,7 +44,7 @@ export const MapContextMenu: React.FC<MapContextMenuProps> = ({ id, copyLocation
         return () => {
             map.off("contextmenu", handler)
         }
-    }, [ref])
+    }, [map])
 
     const handleClose = useCallback(() => {
         setOpened(false)

--- a/apps/sphere/src/components/SourcePanel/index.tsx
+++ b/apps/sphere/src/components/SourcePanel/index.tsx
@@ -19,7 +19,7 @@ export const selector = createSelector([selectors.source.selectSelectedId, selec
         return null
     }
 
-    let meta: SourceMetadata | undefined = undefined
+    let meta: SourceMetadata | undefined
     if (source.type === SourceType.Geojson) {
         meta = source.meta
     } else if (source.type === SourceType.FeatureCollection && !source.pending) {

--- a/apps/sphere/src/lib/sphere-protocol.ts
+++ b/apps/sphere/src/lib/sphere-protocol.ts
@@ -11,7 +11,7 @@ export class SphereProtocol {
         const z = url.searchParams.get("z") ?? "0"
         const x = url.searchParams.get("x") ?? "0"
         const y = url.searchParams.get("y") ?? "0"
-        return [Number.parseInt(z), Number.parseInt(x), Number.parseInt(y)]
+        return [Number.parseInt(z, 10), Number.parseInt(x, 10), Number.parseInt(y, 10)]
     }
 
     public createHandler(): AddProtocolAction {

--- a/apps/sphere/src/sphere-hooks/useMapStore.ts
+++ b/apps/sphere/src/sphere-hooks/useMapStore.ts
@@ -4,9 +4,9 @@ import { useMap } from "react-map-gl/maplibre"
 
 export default function useMapStore(mapId: string) {
     const { [mapId]: ref } = useMap()
+    const map = ref?.getMap() ?? null
 
     useEffect(() => {
-        const map = ref?.getMap()
         if (!map) {
             return
         }
@@ -26,5 +26,5 @@ export default function useMapStore(mapId: string) {
             load.unsubscribe()
             removeMap(mapId)
         }
-    }, [ref, mapId])
+    }, [map, mapId])
 }

--- a/apps/sphere/src/sphere-hooks/usePointerHover.ts
+++ b/apps/sphere/src/sphere-hooks/usePointerHover.ts
@@ -4,7 +4,8 @@ import { useEffect } from "react"
 import { useMap } from "react-map-gl/maplibre"
 
 export default function usePointerHover(mapId: string) {
-    const { [mapId]: map } = useMap()
+    const { [mapId]: ref } = useMap()
+    const map = ref?.getMap() ?? null
     const dispatch = useAppDispatch()
     const layerIds = useAppSelector(selectors.layer.visibleIds)
 

--- a/apps/sphere/src/store/keyboard.test.ts
+++ b/apps/sphere/src/store/keyboard.test.ts
@@ -9,12 +9,7 @@ import { setupKeyboard } from "./keyboard"
 
 const mockCopy = copySelectionAsGeojson as unknown as MockInstance
 
-function makeStore(overrides: {
-    sourceId?: string
-    count?: number
-    wrapFc?: boolean
-    mapTool?: string
-}) {
+function makeStore(overrides: { sourceId?: string; count?: number; wrapFc?: boolean; mapTool?: string }) {
     return {
         getState: () => ({
             app: { mapTool: overrides.mapTool ?? "pan" },

--- a/apps/sphere/src/store/listeners/add-blank-layer.ts
+++ b/apps/sphere/src/store/listeners/add-blank-layer.ts
@@ -28,7 +28,7 @@ listener.startListening({
         )
 
         if (sourceId && source) {
-            let sourceLayer: string | undefined = undefined
+            let sourceLayer: string | undefined
             // Automatically set sourceLayer for MVT sources with only one layer in it
             if (source.type === SourceType.MVT && source.sourceLayers.length === 1) {
                 sourceLayer = source.sourceLayers.at(0)?.id

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
     "formatter": {
         "enabled": true,
         "indentStyle": "space",
@@ -29,10 +29,10 @@
                 "noDebugger": "error",
                 "noConsole": "error",
                 "noArrayIndexKey": "error",
-                "noShadowRestrictedNames": "error"
+                "noShadowRestrictedNames": "error",
+                "noVar": "error"
             },
             "style": {
-                "noVar": "error",
                 "noNonNullAssertion": "error"
             },
             "performance": {
@@ -40,7 +40,8 @@
             },
             "a11y": {
                 "useButtonType": "error",
-                "noSvgWithoutTitle": "error"
+                "noSvgWithoutTitle": "error",
+                "noStaticElementInteractions": "off"
             },
             "complexity": {
                 "noForEach": "error",
@@ -49,6 +50,6 @@
         }
     },
     "files": {
-        "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js"]
+        "includes": ["**/src/**/*.ts", "**/src/**/*.tsx", "**/src/**/*.js"]
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
                 "packages/*"
             ],
             "devDependencies": {
-                "@biomejs/biome": "^1.9.0",
+                "@biomejs/biome": "^2.4.11",
                 "@testing-library/dom": "^10.4.1",
                 "@testing-library/jest-dom": "^6.9.1",
                 "@testing-library/react": "^16.3.2",
@@ -225,11 +225,10 @@
             }
         },
         "node_modules/@biomejs/biome": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-            "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.11.tgz",
+            "integrity": "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==",
             "dev": true,
-            "hasInstallScript": true,
             "license": "MIT OR Apache-2.0",
             "bin": {
                 "biome": "bin/biome"
@@ -242,20 +241,20 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "1.9.4",
-                "@biomejs/cli-darwin-x64": "1.9.4",
-                "@biomejs/cli-linux-arm64": "1.9.4",
-                "@biomejs/cli-linux-arm64-musl": "1.9.4",
-                "@biomejs/cli-linux-x64": "1.9.4",
-                "@biomejs/cli-linux-x64-musl": "1.9.4",
-                "@biomejs/cli-win32-arm64": "1.9.4",
-                "@biomejs/cli-win32-x64": "1.9.4"
+                "@biomejs/cli-darwin-arm64": "2.4.11",
+                "@biomejs/cli-darwin-x64": "2.4.11",
+                "@biomejs/cli-linux-arm64": "2.4.11",
+                "@biomejs/cli-linux-arm64-musl": "2.4.11",
+                "@biomejs/cli-linux-x64": "2.4.11",
+                "@biomejs/cli-linux-x64-musl": "2.4.11",
+                "@biomejs/cli-win32-arm64": "2.4.11",
+                "@biomejs/cli-win32-x64": "2.4.11"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-            "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.11.tgz",
+            "integrity": "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==",
             "cpu": [
                 "arm64"
             ],
@@ -270,9 +269,9 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-            "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.11.tgz",
+            "integrity": "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==",
             "cpu": [
                 "x64"
             ],
@@ -287,9 +286,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-            "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.11.tgz",
+            "integrity": "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==",
             "cpu": [
                 "arm64"
             ],
@@ -304,9 +303,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-            "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.11.tgz",
+            "integrity": "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==",
             "cpu": [
                 "arm64"
             ],
@@ -321,9 +320,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-            "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.11.tgz",
+            "integrity": "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==",
             "cpu": [
                 "x64"
             ],
@@ -338,9 +337,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-            "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.11.tgz",
+            "integrity": "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==",
             "cpu": [
                 "x64"
             ],
@@ -355,9 +354,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-            "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.11.tgz",
+            "integrity": "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==",
             "cpu": [
                 "arm64"
             ],
@@ -372,9 +371,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-            "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.11.tgz",
+            "integrity": "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==",
             "cpu": [
                 "x64"
             ],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "coverage": "npm run coverage -w @sphere/app"
     },
     "devDependencies": {
-        "@biomejs/biome": "^1.9.0",
+        "@biomejs/biome": "^2.4.11",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -1,9 +1,10 @@
 {
-    "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+    "root": false,
+    "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
     "extends": ["../../biome.json"],
     "linter": {
         "rules": {
-            "nursery": {
+            "style": {
                 "noRestrictedImports": {
                     "level": "error",
                     "options": {
@@ -22,6 +23,6 @@
         }
     },
     "files": {
-        "include": ["src/**/*.ts", "src/**/*.tsx"]
+        "includes": ["**/src/**/*.ts", "**/src/**/*.tsx"]
     }
 }

--- a/packages/utils/biome.json
+++ b/packages/utils/biome.json
@@ -1,9 +1,10 @@
 {
-    "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+    "root": false,
+    "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
     "extends": ["../../biome.json"],
     "linter": {
         "rules": {
-            "nursery": {
+            "style": {
                 "noRestrictedImports": {
                     "level": "error",
                     "options": {
@@ -24,6 +25,6 @@
         }
     },
     "files": {
-        "include": ["src/**/*.ts"]
+        "includes": ["**/src/**/*.ts"]
     }
 }


### PR DESCRIPTION
## Summary

- Bump `@biomejs/biome` 1.9.0 → 2.4.11 and migrate configs (`files.includes`, `noVar` → `suspicious`, `noRestrictedImports` out of `nursery`, `"root": false` on package configs).
- Fix new lint errors: `useParseIntRadix`, `noUselessUndefinedInitialization`, and `useExhaustiveDependencies` (stricter in 2.x — flags extra deps).
- Restructure `useMapStore`, `usePointerHover`, `MapContextMenu` to derive `map = ref?.getMap() ?? null` during render. Biome 2.x considers destructured values from `useMap()` as stable, so depending on the computed `map` rather than the `ref` itself keeps the effect semantics correct while satisfying the rule.
- Disable new `a11y/noStaticElementInteractions` — violations in `ImageMarker` hover span and `PropertiesTable` column resizer need real UX work (keyboard focus, separator role with value props). Tracked for follow-up.