### PR TITLE
Disable MapLibre box zoom so shift+drag is free for rect-select

### DIFF
--- a/apps/sphere/src/hooks/useMapNavigation.test.ts
+++ b/apps/sphere/src/hooks/useMapNavigation.test.ts
@@ -24,6 +24,10 @@ function makeMockMap() {
             enable: vi.fn(),
             disable: vi.fn(),
         },
+        boxZoom: {
+            enable: vi.fn(),
+            disable: vi.fn(),
+        },
         on: vi.fn(),
         off: vi.fn(),
     }
@@ -99,5 +103,13 @@ describe("useMapNavigation", () => {
         expect(map.scrollZoom.enable).toHaveBeenCalled()
         expect(map.dragRotate.disable).toHaveBeenCalled()
         expect(map.on).not.toHaveBeenCalled()
+    })
+
+    it("always disables boxZoom so shift+drag is free for rect-select", () => {
+        mockState(ALL_ENABLED, true)
+        const map = makeMockMap()
+        renderHook(() => useMapNavigation(makeRef(map)))
+        expect(map.boxZoom.disable).toHaveBeenCalled()
+        expect(map.boxZoom.enable).not.toHaveBeenCalled()
     })
 })

--- a/apps/sphere/src/hooks/useMapNavigation.ts
+++ b/apps/sphere/src/hooks/useMapNavigation.ts
@@ -19,6 +19,10 @@ export default function useMapNavigation(ref?: MapRef): void {
         const effectiveScrollZoom = scrollZoom
         const effectiveDragRotate = navigationEnabled && dragRotate
 
+        // Shift+drag is reserved for rect-select; MapLibre's built-in box zoom
+        // would otherwise draw its own rectangle and zoom on release.
+        map.boxZoom.disable()
+
         if (effectiveDragPan) {
             map.dragPan.enable()
         } else {


### PR DESCRIPTION
MapLibre's built-in shift+drag box zoom fires alongside the Sources-tab rect-select tool, causing an unwanted zoom on every selection. Always disable `map.boxZoom` in `useMapNavigation` so the gesture is reserved for rect-select.

Closes #221