### PR TITLE
Fix map crash when setProjection runs before style load

### DIFF
--- a/apps/sphere/src/components/SphereMap/map-body.tsx
+++ b/apps/sphere/src/components/SphereMap/map-body.tsx
@@ -57,7 +57,7 @@ export default function MapBody({ mapId }: MapBodyProps) {
     useSky(map, sky)
 
     const projection = useAppSelector(selectors.projection.projection)
-    useProjection(map, projection, "mercator")
+    useProjection(map, projection)
     usePointerHover(mapId)
     useFeatureState(map)
     useFeatureProperties(map, 50)

--- a/apps/sphere/src/components/SphereMap/map-body.tsx
+++ b/apps/sphere/src/components/SphereMap/map-body.tsx
@@ -1,11 +1,11 @@
 import useMapNavigation from "@/hooks/useMapNavigation"
+import useProjection from "@/hooks/useProjection"
 import useSky from "@/hooks/useSky"
 import useTerrain from "@/hooks/useTerrain"
 import useFeatureProperties from "@/sphere-hooks/useFeatureProperties"
 import useFeatureState from "@/sphere-hooks/useFeatureState"
 import useMapStore from "@/sphere-hooks/useMapStore"
 import usePointerHover from "@/sphere-hooks/usePointerHover"
-import useProjection from "@/sphere-hooks/useProjection"
 import useTileBoundaries from "@/sphere-hooks/useTileBoundaries"
 import { selectors } from "@/store"
 import { selectShowAttribution } from "@/store/app"
@@ -56,7 +56,8 @@ export default function MapBody({ mapId }: MapBodyProps) {
     const sky = useAppSelector(selectSkySpecification)
     useSky(map, sky)
 
-    useProjection(map, "mercator")
+    const projection = useAppSelector(selectors.projection.projection)
+    useProjection(map, projection, "mercator")
     usePointerHover(mapId)
     useFeatureState(map)
     useFeatureProperties(map, 50)

--- a/apps/sphere/src/hooks/useProjection.test.ts
+++ b/apps/sphere/src/hooks/useProjection.test.ts
@@ -1,17 +1,7 @@
-import { configureStore } from "@reduxjs/toolkit"
 import { renderHook } from "@testing-library/react"
 import type { MapRef } from "react-map-gl/maplibre"
-import { Provider } from "react-redux"
 import { describe, expect, it, vi } from "vitest"
 import useProjection from "./useProjection"
-
-const makeStore = (projection: "mercator" | "globe", drawing = false) =>
-    configureStore({
-        reducer: {
-            projection: () => ({ value: projection }),
-            draw: () => ({ sourceId: drawing ? "src1" : null, selectedIds: [] }),
-        },
-    })
 
 type MockMap = {
     setProjection: ReturnType<typeof vi.fn>
@@ -30,28 +20,21 @@ const makeMap = (styleLoaded: boolean): MockMap => {
 
 const makeRef = (map: MockMap): MapRef => ({ getMap: () => map }) as unknown as MapRef
 
-const wrapper =
-    (store: ReturnType<typeof makeStore>) =>
-    ({ children }: { children: React.ReactNode }) => <Provider store={store}>{children}</Provider>
-
 describe("useProjection", () => {
     it("does nothing when ref is undefined", () => {
-        const store = makeStore("globe")
-        renderHook(() => useProjection(undefined, "mercator"), { wrapper: wrapper(store) })
+        renderHook(() => useProjection(undefined, "globe", "mercator"))
     })
 
     it("calls setProjection immediately when style is loaded", () => {
         const map = makeMap(true)
-        const store = makeStore("globe")
-        renderHook(() => useProjection(makeRef(map), "mercator"), { wrapper: wrapper(store) })
+        renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
         expect(map.setProjection).toHaveBeenCalledWith({ type: "globe" })
         expect(map.on).not.toHaveBeenCalled()
     })
 
     it("defers setProjection to load event when style is not loaded", () => {
         const map = makeMap(false)
-        const store = makeStore("globe")
-        renderHook(() => useProjection(makeRef(map), "mercator"), { wrapper: wrapper(store) })
+        renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
         expect(map.setProjection).not.toHaveBeenCalled()
         expect(map.on).toHaveBeenCalledWith("load", expect.any(Function))
 
@@ -62,10 +45,7 @@ describe("useProjection", () => {
 
     it("restores fallback projection on unmount when style is loaded", () => {
         const map = makeMap(true)
-        const store = makeStore("globe")
-        const { unmount } = renderHook(() => useProjection(makeRef(map), "mercator"), {
-            wrapper: wrapper(store),
-        })
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
         map.setProjection.mockClear()
         unmount()
         expect(map.setProjection).toHaveBeenCalledWith({ type: "mercator" })
@@ -73,10 +53,7 @@ describe("useProjection", () => {
 
     it("does not call setProjection on unmount when style is no longer loaded", () => {
         const map = makeMap(true)
-        const store = makeStore("globe")
-        const { unmount } = renderHook(() => useProjection(makeRef(map), "mercator"), {
-            wrapper: wrapper(store),
-        })
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
         map.setProjection.mockClear()
         map.isStyleLoaded.mockReturnValue(false)
         unmount()
@@ -85,10 +62,7 @@ describe("useProjection", () => {
 
     it("unsubscribes load listener on unmount", () => {
         const map = makeMap(false)
-        const store = makeStore("globe")
-        const { unmount } = renderHook(() => useProjection(makeRef(map), "mercator"), {
-            wrapper: wrapper(store),
-        })
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
         const subscription = map.on.mock.results[0].value as { unsubscribe: ReturnType<typeof vi.fn> }
         unmount()
         expect(subscription.unsubscribe).toHaveBeenCalled()

--- a/apps/sphere/src/hooks/useProjection.test.ts
+++ b/apps/sphere/src/hooks/useProjection.test.ts
@@ -5,14 +5,16 @@ import useProjection from "./useProjection"
 
 type MockMap = {
     setProjection: ReturnType<typeof vi.fn>
+    getProjection: ReturnType<typeof vi.fn>
     isStyleLoaded: ReturnType<typeof vi.fn>
     on: ReturnType<typeof vi.fn>
 }
 
-const makeMap = (styleLoaded: boolean): MockMap => {
+const makeMap = (styleLoaded: boolean, currentProjection = { type: "mercator" as const }): MockMap => {
     const subscription = { unsubscribe: vi.fn() }
     return {
         setProjection: vi.fn(),
+        getProjection: vi.fn(() => currentProjection),
         isStyleLoaded: vi.fn(() => styleLoaded),
         on: vi.fn(() => subscription),
     }
@@ -22,47 +24,56 @@ const makeRef = (map: MockMap): MapRef => ({ getMap: () => map }) as unknown as 
 
 describe("useProjection", () => {
     it("does nothing when ref is undefined", () => {
-        renderHook(() => useProjection(undefined, "globe", "mercator"))
+        renderHook(() => useProjection(undefined, "globe"))
     })
 
     it("calls setProjection immediately when style is loaded", () => {
         const map = makeMap(true)
-        renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
+        renderHook(() => useProjection(makeRef(map), "globe"))
         expect(map.setProjection).toHaveBeenCalledWith({ type: "globe" })
         expect(map.on).not.toHaveBeenCalled()
     })
 
     it("defers setProjection to load event when style is not loaded", () => {
         const map = makeMap(false)
-        renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
+        renderHook(() => useProjection(makeRef(map), "globe"))
         expect(map.setProjection).not.toHaveBeenCalled()
         expect(map.on).toHaveBeenCalledWith("load", expect.any(Function))
 
+        map.isStyleLoaded.mockReturnValue(true)
         const loadHandler = map.on.mock.calls[0][1] as () => void
         loadHandler()
         expect(map.setProjection).toHaveBeenCalledWith({ type: "globe" })
     })
 
-    it("restores fallback projection on unmount when style is loaded", () => {
-        const map = makeMap(true)
-        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
+    it("restores the previous projection on unmount", () => {
+        const previous = { type: "mercator" as const }
+        const map = makeMap(true, previous)
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe"))
         map.setProjection.mockClear()
         unmount()
-        expect(map.setProjection).toHaveBeenCalledWith({ type: "mercator" })
+        expect(map.setProjection).toHaveBeenCalledWith(previous)
     })
 
-    it("does not call setProjection on unmount when style is no longer loaded", () => {
+    it("does not restore on unmount if style is no longer loaded", () => {
         const map = makeMap(true)
-        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe"))
         map.setProjection.mockClear()
         map.isStyleLoaded.mockReturnValue(false)
         unmount()
         expect(map.setProjection).not.toHaveBeenCalled()
     })
 
+    it("does not restore on unmount if apply never ran (deferred and never loaded)", () => {
+        const map = makeMap(false)
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe"))
+        unmount()
+        expect(map.setProjection).not.toHaveBeenCalled()
+    })
+
     it("unsubscribes load listener on unmount", () => {
         const map = makeMap(false)
-        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe", "mercator"))
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "globe"))
         const subscription = map.on.mock.results[0].value as { unsubscribe: ReturnType<typeof vi.fn> }
         unmount()
         expect(subscription.unsubscribe).toHaveBeenCalled()

--- a/apps/sphere/src/hooks/useProjection.ts
+++ b/apps/sphere/src/hooks/useProjection.ts
@@ -4,33 +4,36 @@ import type { MapRef } from "react-map-gl/maplibre"
 
 type ProjectionType = ProjectionSpecification["type"]
 
-export default function useProjection(ref: MapRef | undefined, projection: ProjectionType, fallback: ProjectionType) {
+export default function useProjection(ref: MapRef | undefined, projection: ProjectionType) {
     useEffect(() => {
         const map = ref?.getMap()
         if (!map) {
             return
         }
 
+        let previous: ProjectionSpecification | undefined
+
         const apply = () => {
+            previous = map.getProjection()
             map.setProjection({ type: projection })
+        }
+
+        const restore = () => {
+            if (previous && map.isStyleLoaded()) {
+                map.setProjection(previous)
+            }
         }
 
         if (map.isStyleLoaded()) {
             apply()
-            return () => {
-                if (map.isStyleLoaded()) {
-                    map.setProjection({ type: fallback })
-                }
-            }
+            return restore
         }
 
         const load = map.on("load", apply)
 
         return () => {
             load.unsubscribe()
-            if (map.isStyleLoaded()) {
-                map.setProjection({ type: fallback })
-            }
+            restore()
         }
-    }, [ref, projection, fallback])
+    }, [ref, projection])
 }

--- a/apps/sphere/src/hooks/useProjection.ts
+++ b/apps/sphere/src/hooks/useProjection.ts
@@ -1,16 +1,10 @@
-import { selectors } from "@/store"
-import { useAppSelector } from "@/store/hooks"
-import type { Projection } from "@/types"
+import type { ProjectionSpecification } from "maplibre-gl"
 import { useEffect } from "react"
 import type { MapRef } from "react-map-gl/maplibre"
 
-export type ProjectionProps = {
-    fallback: Projection
-}
+type ProjectionType = ProjectionSpecification["type"]
 
-export default function useProjection(ref: MapRef | undefined, fallback: Projection) {
-    const projection = useAppSelector(selectors.projection.projection)
-
+export default function useProjection(ref: MapRef | undefined, projection: ProjectionType, fallback: ProjectionType) {
     useEffect(() => {
         const map = ref?.getMap()
         if (!map) {
@@ -39,6 +33,4 @@ export default function useProjection(ref: MapRef | undefined, fallback: Project
             }
         }
     }, [ref, projection, fallback])
-
-    return null
 }

--- a/apps/sphere/src/sphere-hooks/useProjection.test.tsx
+++ b/apps/sphere/src/sphere-hooks/useProjection.test.tsx
@@ -1,0 +1,96 @@
+import { configureStore } from "@reduxjs/toolkit"
+import { renderHook } from "@testing-library/react"
+import type { MapRef } from "react-map-gl/maplibre"
+import { Provider } from "react-redux"
+import { describe, expect, it, vi } from "vitest"
+import useProjection from "./useProjection"
+
+const makeStore = (projection: "mercator" | "globe", drawing = false) =>
+    configureStore({
+        reducer: {
+            projection: () => ({ value: projection }),
+            draw: () => ({ sourceId: drawing ? "src1" : null, selectedIds: [] }),
+        },
+    })
+
+type MockMap = {
+    setProjection: ReturnType<typeof vi.fn>
+    isStyleLoaded: ReturnType<typeof vi.fn>
+    on: ReturnType<typeof vi.fn>
+}
+
+const makeMap = (styleLoaded: boolean): MockMap => {
+    const subscription = { unsubscribe: vi.fn() }
+    return {
+        setProjection: vi.fn(),
+        isStyleLoaded: vi.fn(() => styleLoaded),
+        on: vi.fn(() => subscription),
+    }
+}
+
+const makeRef = (map: MockMap): MapRef => ({ getMap: () => map }) as unknown as MapRef
+
+const wrapper =
+    (store: ReturnType<typeof makeStore>) =>
+    ({ children }: { children: React.ReactNode }) => <Provider store={store}>{children}</Provider>
+
+describe("useProjection", () => {
+    it("does nothing when ref is undefined", () => {
+        const store = makeStore("globe")
+        renderHook(() => useProjection(undefined, "mercator"), { wrapper: wrapper(store) })
+    })
+
+    it("calls setProjection immediately when style is loaded", () => {
+        const map = makeMap(true)
+        const store = makeStore("globe")
+        renderHook(() => useProjection(makeRef(map), "mercator"), { wrapper: wrapper(store) })
+        expect(map.setProjection).toHaveBeenCalledWith({ type: "globe" })
+        expect(map.on).not.toHaveBeenCalled()
+    })
+
+    it("defers setProjection to load event when style is not loaded", () => {
+        const map = makeMap(false)
+        const store = makeStore("globe")
+        renderHook(() => useProjection(makeRef(map), "mercator"), { wrapper: wrapper(store) })
+        expect(map.setProjection).not.toHaveBeenCalled()
+        expect(map.on).toHaveBeenCalledWith("load", expect.any(Function))
+
+        const loadHandler = map.on.mock.calls[0][1] as () => void
+        loadHandler()
+        expect(map.setProjection).toHaveBeenCalledWith({ type: "globe" })
+    })
+
+    it("restores fallback projection on unmount when style is loaded", () => {
+        const map = makeMap(true)
+        const store = makeStore("globe")
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "mercator"), {
+            wrapper: wrapper(store),
+        })
+        map.setProjection.mockClear()
+        unmount()
+        expect(map.setProjection).toHaveBeenCalledWith({ type: "mercator" })
+    })
+
+    it("does not call setProjection on unmount when style is no longer loaded", () => {
+        const map = makeMap(true)
+        const store = makeStore("globe")
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "mercator"), {
+            wrapper: wrapper(store),
+        })
+        map.setProjection.mockClear()
+        map.isStyleLoaded.mockReturnValue(false)
+        unmount()
+        expect(map.setProjection).not.toHaveBeenCalled()
+    })
+
+    it("unsubscribes load listener on unmount", () => {
+        const map = makeMap(false)
+        const store = makeStore("globe")
+        const { unmount } = renderHook(() => useProjection(makeRef(map), "mercator"), {
+            wrapper: wrapper(store),
+        })
+        const subscription = map.on.mock.results[0].value as { unsubscribe: ReturnType<typeof vi.fn> }
+        unmount()
+        expect(subscription.unsubscribe).toHaveBeenCalled()
+    })
+})

--- a/apps/sphere/src/sphere-hooks/useProjection.ts
+++ b/apps/sphere/src/sphere-hooks/useProjection.ts
@@ -17,14 +17,26 @@ export default function useProjection(ref: MapRef | undefined, fallback: Project
             return
         }
 
-        map.setProjection({
-            type: projection,
-        })
+        const apply = () => {
+            map.setProjection({ type: projection })
+        }
+
+        if (map.isStyleLoaded()) {
+            apply()
+            return () => {
+                if (map.isStyleLoaded()) {
+                    map.setProjection({ type: fallback })
+                }
+            }
+        }
+
+        const load = map.on("load", apply)
 
         return () => {
-            map.setProjection({
-                type: fallback,
-            })
+            load.unsubscribe()
+            if (map.isStyleLoaded()) {
+                map.setProjection({ type: fallback })
+            }
         }
     }, [ref, projection, fallback])
 


### PR DESCRIPTION
Fixes #216. `useProjection` called `map.setProjection()` synchronously without checking `isStyleLoaded()`; MapLibre throws `"Style is not done loading."` when the style isn't ready, which the `ErrorBoundary` rendered as the crash screen on ~20-30% of cold starts. Mirrored the `useSky`/`useTerrain` pattern: apply immediately when style is loaded, otherwise defer to `map.on("load", ...)`, and guard the cleanup with `isStyleLoaded()`.