### PR TITLE
Fix stale CI path filters in test-frontend.yaml

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -2,12 +2,13 @@ name: "test-frontend"
 on:
     pull_request:
         paths:
-            - "src/**"
+            - "apps/**"
+            - "packages/**"
             - "package.json"
-            - "tsconfig.json"
-            - "vite.config.ts"
-            - "biome.json"
             - "package-lock.json"
+            - "tsconfig.base.json"
+            - "biome.json"
+            - ".github/workflows/test-frontend.yaml"
 
 jobs:
     lint:


### PR DESCRIPTION
Update the `test-frontend` workflow `paths` trigger to the monorepo layout (`apps/**`, `packages/**`, `tsconfig.base.json`) so frontend PRs actually run lint/typecheck/format/test/build. The old filters referenced pre-monorepo paths (`src/**`, root `vite.config.ts`/`tsconfig.json`) that no longer exist, so the workflow was silently skipped on most frontend changes.

Closes #225