### PR TITLE
Fix PhotoLayer crash when a layer filter is set

### DIFF
--- a/apps/sphere/src/components/PhotoLayer/hooks.test.ts
+++ b/apps/sphere/src/components/PhotoLayer/hooks.test.ts
@@ -10,17 +10,32 @@ vi.mock("@/store/hooks", () => ({
     useAppSelector: vi.fn(),
 }))
 
-vi.mock("@/lib/source-reader", () => ({
-    SourceReader: vi.fn().mockImplementation(() => ({
-        getGeojson: vi.fn().mockResolvedValue(null),
-    })),
+const { sourceReaderMock, getGeojsonMock, getFilteredMock } = vi.hoisted(() => ({
+    sourceReaderMock: vi.fn(),
+    getGeojsonMock: vi.fn(),
+    getFilteredMock: vi.fn(),
 }))
 
+vi.mock("@/lib/source-reader", () => ({
+    SourceReader: sourceReaderMock,
+}))
+
+import { filteredSourceId } from "@/lib/layer-source"
 import { useAppSelector } from "@/store/hooks"
 import { useFeatures } from "./hooks"
 
 const SOURCE_ID = "test-source"
 const LAYER_ID = "test-layer"
+
+beforeEach(() => {
+    getGeojsonMock.mockReset().mockResolvedValue(null)
+    getFilteredMock.mockReset().mockResolvedValue(null)
+    // `new SourceReader(...)` needs a constructible implementation, so this
+    // cannot be an arrow function.
+    sourceReaderMock.mockReset().mockImplementation(function SourceReaderStub() {
+        return { getGeojson: getGeojsonMock, getFiltered: getFilteredMock }
+    })
+})
 
 type MapEventKey = keyof MapEventType | keyof MapLayerEventType
 
@@ -149,5 +164,82 @@ describe("useTileFeatures event listener behavior", () => {
     it("does not register listeners when map is undefined", () => {
         const { result } = renderHook(() => useFeatures({ sourceId: SOURCE_ID, layerId: LAYER_ID, map: undefined }))
         expect(result.current).toEqual([])
+    })
+})
+
+describe("useFeatures source resolution", () => {
+    const FILTER_EXPRESSION = [">", ["get", "score"], 0.9]
+
+    function mockState(state: unknown) {
+        vi.mocked(useAppSelector).mockImplementation(selector => selector(state as RootState))
+    }
+
+    function geojsonState(layerFilter?: unknown) {
+        return {
+            source: {
+                items: {
+                    [SOURCE_ID]: { id: SOURCE_ID, type: SourceType.Geojson },
+                },
+            },
+            layer: {
+                items: {
+                    [LAYER_ID]: {
+                        id: LAYER_ID,
+                        sourceId: SOURCE_ID,
+                        ...(layerFilter ? { filter: { expression: layerFilter, error: null } } : {}),
+                    },
+                },
+            },
+        }
+    }
+
+    it("reads unfiltered geojson when the layer has no filter", async () => {
+        mockState(geojsonState())
+
+        await act(async () => {
+            renderHook(() => useFeatures({ sourceId: SOURCE_ID, layerId: LAYER_ID, map: undefined }))
+        })
+
+        expect(sourceReaderMock).toHaveBeenCalledWith(SOURCE_ID)
+        expect(getGeojsonMock).toHaveBeenCalled()
+        expect(getFilteredMock).not.toHaveBeenCalled()
+    })
+
+    it("does not throw when given a filtered side-source id absent from the source slice", async () => {
+        mockState(geojsonState(FILTER_EXPRESSION))
+
+        await act(async () => {
+            expect(() =>
+                renderHook(() =>
+                    useFeatures({ sourceId: filteredSourceId(LAYER_ID), layerId: LAYER_ID, map: undefined }),
+                ),
+            ).not.toThrow()
+        })
+    })
+
+    it("reads filtered geojson from the underlying source for a filtered side-source id", async () => {
+        mockState(geojsonState(FILTER_EXPRESSION))
+
+        await act(async () => {
+            renderHook(() => useFeatures({ sourceId: filteredSourceId(LAYER_ID), layerId: LAYER_ID, map: undefined }))
+        })
+
+        expect(sourceReaderMock).toHaveBeenCalledWith(SOURCE_ID)
+        expect(getFilteredMock).toHaveBeenCalledWith(JSON.stringify(FILTER_EXPRESSION))
+        expect(getGeojsonMock).not.toHaveBeenCalled()
+    })
+
+    it("returns no features when the side-source cannot be resolved to a layer", async () => {
+        mockState({ source: { items: {} }, layer: { items: {} } })
+
+        let result: { current: GeoJSON.Feature[] } | undefined
+        await act(async () => {
+            result = renderHook(() =>
+                useFeatures({ sourceId: filteredSourceId("missing-layer"), layerId: LAYER_ID, map: undefined }),
+            ).result
+        })
+
+        expect(result?.current).toEqual([])
+        expect(sourceReaderMock).not.toHaveBeenCalled()
     })
 })

--- a/apps/sphere/src/components/PhotoLayer/hooks.ts
+++ b/apps/sphere/src/components/PhotoLayer/hooks.ts
@@ -1,5 +1,7 @@
+import { filteredLayerId } from "@/lib/layer-source"
 import { nextId } from "@/lib/nextId"
 import { SourceReader } from "@/lib/source-reader"
+import type { RootState } from "@/store"
 import { useAppSelector } from "@/store/hooks"
 import { type Id, SourceType } from "@/types"
 import type { FilterSpecification } from "maplibre-gl"
@@ -13,19 +15,46 @@ type UseFeaturesOptions = {
     filter?: FilterSpecification
 }
 
+/**
+ * `sourceId` is a MapLibre source id, which for a filtered layer is the
+ * side-source created by `FilteredLayerSource` and therefore absent from the
+ * source slice. Resolve it back to the source entry it was derived from,
+ * together with the layer filter that side-source represents.
+ */
+function selectResolvedSource(state: RootState, mapSourceId: Id) {
+    const layerId = filteredLayerId(mapSourceId)
+    if (layerId === null) {
+        return { source: state.source.items[mapSourceId], filter: null }
+    }
+    const layer = state.layer.items[layerId]
+    const sourceId = layer?.sourceId
+    return {
+        source: sourceId ? state.source.items[sourceId] : undefined,
+        filter: layer?.filter?.expression ?? null,
+    }
+}
+
+function selectIsTiled(state: RootState, mapSourceId: Id): boolean {
+    return selectResolvedSource(state, mapSourceId).source?.type === SourceType.MVT
+}
+
+function selectReaderSourceId(state: RootState, mapSourceId: Id): Id | null {
+    const { source } = selectResolvedSource(state, mapSourceId)
+    return source?.type === SourceType.Geojson ? source.id : null
+}
+
+/** Serialized layer filter to apply when reading, or null to read everything. */
+function selectReaderFilterJson(state: RootState, mapSourceId: Id): string | null {
+    const { source, filter } = selectResolvedSource(state, mapSourceId)
+    if (source?.type !== SourceType.Geojson || filter === null) {
+        return null
+    }
+    return JSON.stringify(filter)
+}
+
 function useTileFeatures({ map, sourceId, layerId, filter }: UseFeaturesOptions): GeoJSON.Feature[] | null {
     const [features, setFeatures] = useState<GeoJSON.Feature[]>([])
-    const ok = useAppSelector(state => {
-        const source = state.source.items[sourceId]
-        switch (source.type) {
-            case SourceType.MVT: {
-                return true
-            }
-            default: {
-                return false
-            }
-        }
-    })
+    const ok = useAppSelector(state => selectIsTiled(state, sourceId))
     useEffect(() => {
         if (!ok || !map) {
             return
@@ -64,17 +93,8 @@ function useTileFeatures({ map, sourceId, layerId, filter }: UseFeaturesOptions)
 
 export function useFeatures({ sourceId, layerId, map, filter }: UseFeaturesOptions): GeoJSON.Feature[] {
     const [features, setFeatures] = useState<GeoJSON.Feature[]>([])
-    const sourceIdForReader = useAppSelector(state => {
-        const source = state.source.items[sourceId]
-        switch (source.type) {
-            case SourceType.Geojson: {
-                return source.id
-            }
-            default: {
-                return null
-            }
-        }
-    })
+    const sourceIdForReader = useAppSelector(state => selectReaderSourceId(state, sourceId))
+    const filterJson = useAppSelector(state => selectReaderFilterJson(state, sourceId))
 
     useEffect(() => {
         if (!sourceIdForReader) {
@@ -84,7 +104,7 @@ export function useFeatures({ sourceId, layerId, map, filter }: UseFeaturesOptio
         let mount = true
         const f = async () => {
             const reader = new SourceReader(sourceIdForReader)
-            const data = await reader.getGeojson()
+            const data = filterJson === null ? await reader.getGeojson() : await reader.getFiltered(filterJson)
             if (!data) {
                 return
             }
@@ -102,7 +122,7 @@ export function useFeatures({ sourceId, layerId, map, filter }: UseFeaturesOptio
         return () => {
             mount = false
         }
-    }, [sourceIdForReader])
+    }, [sourceIdForReader, filterJson])
 
     const tf = useTileFeatures({
         sourceId,

--- a/apps/sphere/src/lib/layer-source.test.ts
+++ b/apps/sphere/src/lib/layer-source.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from "vitest"
-import { filteredSourceId, resolveSourceId } from "./layer-source"
+import { filteredLayerId, filteredSourceId, resolveSourceId } from "./layer-source"
 
 describe("filteredSourceId", () => {
     it("prepends layer- prefix", () => {
         expect(filteredSourceId("abc")).toBe("layer-abc")
+    })
+})
+
+describe("filteredLayerId", () => {
+    it("extracts the layer id from a filtered source id", () => {
+        expect(filteredLayerId("layer-abc")).toBe("abc")
+    })
+
+    it("round-trips with filteredSourceId", () => {
+        expect(filteredLayerId(filteredSourceId("abc"))).toBe("abc")
+    })
+
+    it("returns null for a regular source id", () => {
+        expect(filteredLayerId("source-1")).toBeNull()
     })
 })
 

--- a/apps/sphere/src/lib/layer-source.ts
+++ b/apps/sphere/src/lib/layer-source.ts
@@ -4,10 +4,21 @@ export function filteredSourceId(layerId: string): string {
     return `${FILTERED_SOURCE_PREFIX}${layerId}`
 }
 
-export function resolveSourceId(mapSourceId: string, layers: Record<string, { sourceId?: string }>): string {
-    if (mapSourceId.startsWith(FILTERED_SOURCE_PREFIX)) {
-        const layerId = mapSourceId.slice(FILTERED_SOURCE_PREFIX.length)
-        return layers[layerId]?.sourceId ?? mapSourceId
+/**
+ * Returns the layer id encoded in a filtered side-source id, or null when the
+ * id refers to a real source rather than a filter side-source.
+ */
+export function filteredLayerId(mapSourceId: string): string | null {
+    if (!mapSourceId.startsWith(FILTERED_SOURCE_PREFIX)) {
+        return null
     }
-    return mapSourceId
+    return mapSourceId.slice(FILTERED_SOURCE_PREFIX.length)
+}
+
+export function resolveSourceId(mapSourceId: string, layers: Record<string, { sourceId?: string }>): string {
+    const layerId = filteredLayerId(mapSourceId)
+    if (layerId === null) {
+        return mapSourceId
+    }
+    return layers[layerId]?.sourceId ?? mapSourceId
 }


### PR DESCRIPTION
## Summary

closes #241

- Fix a crash in `PhotoLayer` when a layer filter is active on a non-MVT source. `SphereLayer` swaps the MapLibre source id for the `layer-<layerId>` side-source created by `FilteredLayerSource`, which is absent from the Redux `source` slice, so the unguarded `state.source.items[sourceId].type` lookup in `useFeatures`/`useTileFeatures` threw `TypeError: undefined is not an object (evaluating 'source.type')`.
- Resolve the side-source id back to its underlying source entry and read filtered data via `source_get_filtered`, so a filtered photo layer renders the filtered subset instead of every feature.
- Add `filteredLayerId()` to `lib/layer-source.ts` as the inverse of `filteredSourceId()`, and rewrite `resolveSourceId()` in terms of it so the `layer-` prefix stays defined in one place.
