### PR TITLE
fix(ui): stop properties popup from blocking map clicks

### DIFF
--- a/apps/sphere/src/components/PropertiesPopup/index.test.tsx
+++ b/apps/sphere/src/components/PropertiesPopup/index.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@/test-utils"
+import { configureStore } from "@reduxjs/toolkit"
+import { Provider } from "react-redux"
+import { describe, expect, it } from "vitest"
+import PropertiesPopup from "."
+import type { PropertiesEntry } from "@/store/properties"
+
+const makeStore = (entries?: PropertiesEntry[]) =>
+    configureStore({
+        reducer: {
+            app: () => ({ mapTool: "info" }),
+            properties: () => ({ entries }),
+        },
+    })
+
+const renderPopup = (entries?: PropertiesEntry[]) =>
+    render(
+        <Provider store={makeStore(entries)}>
+            <PropertiesPopup />
+        </Provider>,
+    )
+
+const entries: PropertiesEntry[] = [{ id: 1, values: { name: "Alpha" } }]
+
+describe("PropertiesPopup", () => {
+    it("renders nothing without entries", () => {
+        const { container } = renderPopup()
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it("renders the properties of every entry", () => {
+        renderPopup(entries)
+        expect(screen.getByText("Properties")).toBeInTheDocument()
+        expect(screen.getByText("name")).toBeInTheDocument()
+        expect(screen.getByText("Alpha")).toBeInTheDocument()
+    })
+
+    it("puts the visible panel directly in the overlay region, with no transparent block around it", () => {
+        renderPopup(entries)
+        const panel = screen.getByText("Properties").parentElement
+        const region = panel?.parentElement
+        if (!panel || !region) {
+            throw new Error("panel not found")
+        }
+        // The region wrapper is click-through; only its direct child — the panel
+        // itself — receives mouse events. Any wrapper in between would blanket
+        // the map with an invisible, click-eating block.
+        expect(window.getComputedStyle(region).pointerEvents).toBe("none")
+        expect(window.getComputedStyle(panel).pointerEvents).toBe("auto")
+        expect(window.getComputedStyle(panel).height).not.toBe("100%")
+    })
+})

--- a/apps/sphere/src/components/PropertiesPopup/index.tsx
+++ b/apps/sphere/src/components/PropertiesPopup/index.tsx
@@ -1,21 +1,20 @@
 import { selectors } from "@/store/selectors"
 import { useAppSelector } from "@/store/hooks"
 import { Overlay, PropertiesViewer } from "@sphere/ui"
-import { Container, Paper, Title } from "@mantine/core"
+import { Paper, Title } from "@mantine/core"
 
-const CONTAINER_STYLE: React.CSSProperties = {
-    minWidth: 300,
-    height: "100%",
-}
-
+// The panel is sized by its content and capped by the overlay region, so it
+// never covers the map with an invisible full-height block.
 const PAPER_STYLE: React.CSSProperties = {
-    maxHeight: "100%",
+    minWidth: 300,
+    minHeight: 0,
     display: "flex",
     flexDirection: "column",
     overflow: "hidden",
 }
 
 const BODY_STYLE: React.CSSProperties = {
+    minHeight: 0,
     overflowY: "auto",
 }
 
@@ -28,16 +27,14 @@ export default function PropertiesPopup() {
     return (
         <Overlay
             topRight={
-                <Container pt={"lg"} style={CONTAINER_STYLE}>
-                    <Paper p={"sm"} style={PAPER_STYLE}>
-                        <Title order={3}>Properties</Title>
-                        <div style={BODY_STYLE}>
-                            {entries.map(x => (
-                                <PropertiesViewer key={x.id} properties={x.items} />
-                            ))}
-                        </div>
-                    </Paper>
-                </Container>
+                <Paper p={"sm"} style={PAPER_STYLE}>
+                    <Title order={3}>Properties</Title>
+                    <div style={BODY_STYLE}>
+                        {entries.map(x => (
+                            <PropertiesViewer key={x.id} properties={x.items} />
+                        ))}
+                    </div>
+                </Paper>
             }
         />
     )

--- a/packages/ui/src/Overlay/index.test.tsx
+++ b/packages/ui/src/Overlay/index.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest"
+import { render, screen } from "../test-utils"
+import { Overlay } from "."
+
+function getRegion(testId: string) {
+    const content = screen.getByTestId(testId)
+    const region = content.parentElement
+    if (!region) {
+        throw new Error(`region wrapper for ${testId} not found`)
+    }
+    return region
+}
+
+describe("Overlay", () => {
+    it("renders only the provided regions", () => {
+        render(<Overlay topRight={<div data-testid="tr">tr</div>} />)
+        expect(screen.getByTestId("tr")).toBeInTheDocument()
+        expect(screen.queryByTestId("b")).not.toBeInTheDocument()
+    })
+
+    it("keeps the root container transparent to the mouse", () => {
+        render(<Overlay topRight={<div data-testid="tr">tr</div>} />)
+        const container = getRegion("tr").parentElement
+        if (!container) {
+            throw new Error("container not found")
+        }
+        expect(window.getComputedStyle(container).pointerEvents).toBe("none")
+    })
+
+    it.each([
+        "topLeft",
+        "topRight",
+        "left",
+        "right",
+        "top",
+        "bottom",
+    ] as const)("%s region wrapper does not capture mouse events, its content does", region => {
+        render(<Overlay {...{ [region]: <div data-testid="content">content</div> }} />)
+        const wrapper = getRegion("content")
+        expect(window.getComputedStyle(wrapper).pointerEvents).toBe("none")
+        expect(window.getComputedStyle(screen.getByTestId("content")).pointerEvents).toBe("auto")
+    })
+
+    it.each([
+        "topLeft",
+        "topRight",
+    ] as const)("%s region is bounded by max-height, not stretched to full height", region => {
+        render(<Overlay {...{ [region]: <div data-testid="content">content</div> }} />)
+        const style = window.getComputedStyle(getRegion("content"))
+        expect(["", "auto"]).toContain(style.bottom)
+        expect(style.maxHeight).not.toBe("none")
+    })
+})

--- a/packages/ui/src/Overlay/index.tsx
+++ b/packages/ui/src/Overlay/index.tsx
@@ -1,57 +1,76 @@
 import { Box, createStyles } from "@mantine/core"
 
-const useStyles = createStyles(theme => ({
-    container: {
-        position: "absolute",
-        top: 0,
-        left: 0,
-        width: "100%",
-        height: "100%",
-        pointerEvents: "none",
-        zIndex: 100,
-    },
+const useStyles = createStyles(theme => {
+    const topLeftOffset = theme.spacing.sm + theme.spacing.xl
+    const topRightOffset = theme.spacing.sm
+    const bottomGap = theme.spacing.sm
 
-    inner: {
-        position: "absolute",
-        pointerEvents: "auto",
-    },
+    return {
+        container: {
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            pointerEvents: "none",
+            zIndex: 100,
+        },
 
-    topLeft: {
-        top: theme.spacing.sm + theme.spacing.xl,
-        left: theme.spacing.md,
-        bottom: theme.spacing.sm,
-    },
+        // Positioning wrappers must stay transparent to the mouse: they can be
+        // wider or taller than their content and would otherwise swallow clicks
+        // meant for the map underneath. Only the content itself is interactive.
+        inner: {
+            position: "absolute",
+            pointerEvents: "none",
+            "& > *": {
+                pointerEvents: "auto",
+            },
+        },
 
-    left: {
-        top: "50%",
-        left: theme.spacing.md,
-        transform: "translateY(-50%)",
-    },
+        // Scrollable regions are bounded with max-height instead of an anchored
+        // bottom edge, so the wrapper shrinks to its content and leaves the rest
+        // of the map clickable.
+        topLeft: {
+            top: topLeftOffset,
+            left: theme.spacing.md,
+            maxHeight: `calc(100% - ${topLeftOffset + bottomGap}px)`,
+            display: "flex",
+            flexDirection: "column",
+        },
 
-    right: {
-        top: "50%",
-        right: theme.spacing.md,
-        transform: "translateY(-50%)",
-    },
+        left: {
+            top: "50%",
+            left: theme.spacing.md,
+            transform: "translateY(-50%)",
+        },
 
-    topRight: {
-        top: theme.spacing.sm,
-        right: theme.spacing.sm,
-        bottom: theme.spacing.sm,
-    },
+        right: {
+            top: "50%",
+            right: theme.spacing.md,
+            transform: "translateY(-50%)",
+        },
 
-    top: {
-        top: theme.spacing.md,
-        left: "50%",
-        transform: "translateX(-50%)",
-    },
+        topRight: {
+            top: topRightOffset,
+            right: theme.spacing.sm,
+            maxHeight: `calc(100% - ${topRightOffset + bottomGap}px)`,
+            display: "flex",
+            flexDirection: "column",
+        },
 
-    bottom: {
-        bottom: theme.spacing.md,
-        left: "50%",
-        transform: "translateX(-50%)",
-    },
-}))
+        top: {
+            top: theme.spacing.md,
+            left: "50%",
+            transform: "translateX(-50%)",
+        },
+
+        bottom: {
+            bottom: theme.spacing.md,
+            left: "50%",
+            transform: "translateX(-50%)",
+        },
+    }
+})
 
 export type OverlayProps = {
     left?: React.ReactNode


### PR DESCRIPTION
## Summary

closes #245

- Fix the properties popup swallowing mouse events over the right part of the map canvas. The `topRight` overlay region was anchored `top`, `right` **and** `bottom`, so it stretched to full canvas height regardless of content while setting `pointer-events: auto`, and `PropertiesPopup` added a second transparent block on top of it via a `Container` with `height: 100%`.
- Make `Overlay` positioning wrappers click-through (`pointer-events: none`) and re-enable events only on their direct children, so a region can never blanket the map with an invisible, click-eating block.
- Bound the stretched regions (`topLeft`, `topRight`) with `max-height: calc(100% - offset)` and lay them out as flex columns instead of anchoring the bottom edge, so the wrapper shrinks to its content while a scrollable panel still gets capped.
- Drop the `Container` from `PropertiesPopup` so the `Paper` sits directly in the overlay region, sized by its content, with `min-height: 0` on the paper and body so the property list scrolls inside the cap. Side effect: the panel sits slightly higher and loses the container's horizontal padding, which was part of the dead zone.
- Add tests for both layers: `Overlay` region wrappers are click-through while their content is interactive and `topLeft`/`topRight` are not anchored to the bottom edge; `PropertiesPopup` renders its panel as a direct child of the region with nothing transparent in between.

## Testing

- `npm test` (445 app + 35 ui + 63 utils tests passing)
- `npm run lint`
- `npm run typecheck`
- `npm run format`
